### PR TITLE
Add --also37 and --dryrun options

### DIFF
--- a/pkgbld/cli.py
+++ b/pkgbld/cli.py
@@ -18,7 +18,8 @@ def main():
     """
     # parse command-line arguments:
     usage_str = ('pbrelease  REPOSITORY_NAME  PACKAGE_NAME  MODEL_VERSION\n'
-                 '                  [--help]  [--version]')
+                 '                  [--help]  [--also37]  [--dryrun]\n'
+                 '                  [--version]')
     parser = argparse.ArgumentParser(
         prog='',
         usage=usage_str,
@@ -27,7 +28,8 @@ def main():
                      'release.  The packages are build locally in a '
                      'temporary workspace and then uploaded to the '
                      'Anaconda Cloud PSLmodels channel for public '
-                     'distribution.')
+                     'distribution.  The built/uploaded packages are '
+                     'for Python 3.6 and optionally Python 3.7.')
     )
     parser.add_argument('REPOSITORY_NAME', nargs='?',
                         help=('Name of repository in the GitHub organization '
@@ -42,6 +44,16 @@ def main():
                               'semantic-versioning pattern. '
                               'Example: 0.23.2'),
                         default=None)
+    parser.add_argument('--also37',
+                        help=('optional flag that causes build/upload of '
+                              'packages for Python 3.7'),
+                        default=False,
+                        action="store_true")
+    parser.add_argument('--dryrun',
+                        help=('optional flag that writes build/upload plan '
+                              'to stdout and quits without executing plan'),
+                        default=False,
+                        action="store_true")
     parser.add_argument('--version',
                         help=('optional flag that writes Package-Builder '
                               'release version to stdout and quits'),
@@ -76,5 +88,6 @@ def main():
         print('USAGE:', usage_str)
         return 1
     # call pkgbld release function with specified parameters
-    pkgbld.release(repo_name, pkg_name, version)
+    pkgbld.release(repo_name, pkg_name, version,
+                   also37=args.also37, dryrun=args.dryrun)
     return 0

--- a/pkgbld/tests/test_release.py
+++ b/pkgbld/tests/test_release.py
@@ -9,15 +9,19 @@ import pytest
 from pkgbld.release import release
 
 
-@pytest.mark.parametrize('rname, pname, version',
-                         [(99, 'taxcalc', '0.23.0'),
-                          ("Tax-Calculator", 99, '0.23.0'),
-                          ("Tax-Calculator", 'taxcalc', 99),
-                          ("Tax-Calculator", 'taxcalc', '0.23'),
-                          ("Tax-Calculator", 'taxcalc', '0.23.0rc1')])
-def test_improper_release_calls(rname, pname, version):
+@pytest.mark.parametrize(
+    'rname, pname, version, also37, dryrun',
+    [(99, 'taxcalc', '0.23.0', False, False),
+     ("Tax-Calculator", 99, '0.23.0', False, False),
+     ("Tax-Calculator", 'taxcalc', 99, False, False),
+     ("Tax-Calculator", 'taxcalc', '0.23', False, False),
+     ("Tax-Calculator", 'taxcalc', '0.23.0rc1', False, False),
+     ("Tax-Calculator", 'taxcalc', '0.23.0', list(), False),
+     ("Tax-Calculator", 'taxcalc', '0.23.0', False, list())]
+)
+def test_improper_release_calls(rname, pname, version, also37, dryrun):
     """
     Test release calls with parameters that generate a ValueError.
     """
     with pytest.raises(ValueError):
-        release(rname, pname, version)
+        release(rname, pname, version, also37, dryrun)


### PR DESCRIPTION
This pull request adds to the `pbrelease` tool two new options:  `--also37`, which builds/uploads packages for Python 3.7 as well as Python 3.6, and `--dryrun`, which shows the build/upload plan and quits without executing the plan.
