### PR TITLE
Add anaconda-client as a required dependency

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,24 @@ Go [here](https://github.com/PSLmodels~/Package-Builder/pulls?q=is%3Apr+is%3Aclo
 for a complete commit history.
 
 
+2018-12-15 Release 0.14.0
+-------------------------
+(last merged pull request is
+[#145](https://github.com/PSLmodels/Package-Builder/pull/145))
+
+**API Changes**
+- None
+
+**New Features**
+- Add `anaconda-client` as a required dependency of Package-Builder
+  [[#145](https://github.com/PSLmodels/Package-Builder/pull/145)
+  by Martin Holmer with need pointed out by Hank Doupe]
+
+
+**Bug Fixes**
+- None
+
+
 2018-12-14 Release 0.13.0
 -------------------------
 (last merged pull request is

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,16 +7,15 @@ for a complete commit history.
 2018-12-15 Release 0.14.0
 -------------------------
 (last merged pull request is
-[#145](https://github.com/PSLmodels/Package-Builder/pull/145))
+[#146](https://github.com/PSLmodels/Package-Builder/pull/146))
 
 **API Changes**
 - None
 
 **New Features**
 - Add `anaconda-client` as a required dependency of Package-Builder
-  [[#145](https://github.com/PSLmodels/Package-Builder/pull/145)
+  [[#146](https://github.com/PSLmodels/Package-Builder/pull/146)
   by Martin Holmer with need pointed out by Hank Doupe]
-
 
 **Bug Fixes**
 - None

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,11 +11,13 @@ requirements:
     - python
     - "conda>=4.5"
     - "conda-build>=3.5"
+    - anaconda-client
 
   run:
     - python
     - "conda>=4.5"
     - "conda-build>=3.5"
+    - anaconda-client
 
 about:
   home: https://github.com/PSLmodels/Package-Builder

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ dependencies:
 - python
 - "conda>=4.5"
 - "conda-build>=3.5"
+- anaconda-client
 - pytest
 - pytest-pep8
 - pytest-xdist


### PR DESCRIPTION
The need for this revision has been pointed out by the testing of release 0.13.0 on a Linux/Python37 platform by @hdoupe.    The following instructions (found high in the results of a Google search) also suggest the need for this revision.

<img width="729" alt="screen shot 2018-12-15 at 12 02 06 am" src="https://user-images.githubusercontent.com/12170745/50043848-267f4b80-0049-11e9-90c8-89e7bc62d65b.png">
