### PR TITLE
Force upload of already uploaded packages; use anaconda-client=1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ this command and getting something like this screen output:
 
 ```
 $ pbrelease --version
-Package-Builder 0.13.0
+Package-Builder 0.16.0
 ```
 
 Then see the information that `pbrelease` expects by asking for help

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,26 @@ Go [here](https://github.com/PSLmodels~/Package-Builder/pulls?q=is%3Apr+is%3Aclo
 for a complete commit history.
 
 
+2018-12-16 Release 0.16.0
+-------------------------
+(last merged pull request is
+[#148](https://github.com/PSLmodels/Package-Builder/pull/148))
+
+**API Changes**
+- None
+
+**New Features**
+- Make `anaconda upload` command overwrite already uploaded packages
+  [[#148](https://github.com/PSLmodels/Package-Builder/pull/148)
+  by Martin Holmer with assistance from Hank Doupe]
+- Avoid using the new 1.7.* versions of anaconda-client package
+  [[#148](https://github.com/PSLmodels/Package-Builder/pull/148)
+  by Martin Holmer with assistance from Hank Doupe]
+
+**Bug Fixes**
+- None
+
+
 2018-12-15 Release 0.15.0
 -------------------------
 (last merged pull request is
@@ -15,7 +35,7 @@ for a complete commit history.
 **New Features**
 - Simplify `anaconda upload` command used by Package-Builder
   [[#147](https://github.com/PSLmodels/Package-Builder/pull/147)
-  by Martin Holmer with assistance from Hand Doupe]
+  by Martin Holmer with assistance from Hank Doupe]
 
 **Bug Fixes**
 - None

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,13 +11,13 @@ requirements:
     - python
     - "conda>=4.5"
     - "conda-build>=3.5"
-    - anaconda-client
+    - anaconda-client=1.6
 
   run:
     - python
     - "conda>=4.5"
     - "conda-build>=3.5"
-    - anaconda-client
+    - anaconda-client=1.6
 
 about:
   home: https://github.com/PSLmodels/Package-Builder

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ dependencies:
 - python
 - "conda>=4.5"
 - "conda-build>=3.5"
-- anaconda-client
+- anaconda-client=1.6
 - pytest
 - pytest-pep8
 - pytest-xdist

--- a/pkgbld/release.py
+++ b/pkgbld/release.py
@@ -176,7 +176,7 @@ def release(repo_name, pkg_name, version, also37=True, dryrun=False):
                'for Python {}').format(pyver))
         for platform in OS_PLATFORMS:
             pkgpath = os.path.join(BUILDS_DIR, platform, pkgfile)
-            cmd = 'anaconda -t {} upload -u {} --skip-existing {}'.format(
+            cmd = 'anaconda -t {} upload -u {} --force {}'.format(
                 token, ANACONDA_USER, pkgpath
             )
             u.os_call(cmd)


### PR DESCRIPTION
The anaconda-client versions 1.7.? are just tagged; they are not labeled as releases.