### PR TITLE
Add datetime to both the :starting and :finishing prints

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,23 @@ Go [here](https://github.com/PSLmodels~/Package-Builder/pulls?q=is%3Apr+is%3Aclo
 for a complete commit history.
 
 
+2018-12-19 Release 0.19.0
+-------------------------
+(last merged pull request is
+[#153](https://github.com/PSLmodels/Package-Builder/pull/153))
+
+**API Changes**
+- None
+
+**New Features**
+- Add datetime to :starting and :finishing prints
+  [[#153](https://github.com/PSLmodels/Package-Builder/pull/153)
+  by Martin Holmer]
+
+**Bug Fixes**
+- None
+
+
 2018-12-18 Release 0.18.0
 -------------------------
 (last merged pull request is

--- a/pkgbld/release.py
+++ b/pkgbld/release.py
@@ -7,6 +7,7 @@ Policy Simulaton Library (PSL) model Anaconda-Cloud package release logic.
 
 import os
 import re
+import time
 import shutil
 import pkgbld.utils as u
 
@@ -109,6 +110,9 @@ def release(repo_name, pkg_name, version, also37=True, dryrun=False):
         print(': Package-Builder is quitting')
         return
 
+    # show date and time
+    print((': Package-Builder is starting at {}'.format(time.asctime())))
+
     # make empty working directory
     if os.path.isdir(WORKING_DIR):
         shutil.rmtree(WORKING_DIR)
@@ -178,7 +182,6 @@ def release(repo_name, pkg_name, version, also37=True, dryrun=False):
             cmd = 'anaconda -t {} upload -u {} --force {}'.format(
                 ANACONDA_TOKEN_FILE, ANACONDA_USER, pkgpath
             )
-            print('upload cmd is <{}>'.format(cmd))
             u.os_call(cmd)
 
     print(': Package-Builder is cleaning-up')
@@ -191,4 +194,4 @@ def release(repo_name, pkg_name, version, also37=True, dryrun=False):
     os.chdir(HOME_DIR)
     shutil.rmtree(WORKING_DIR)
 
-    print(': Package-Builder is finished')
+    print(': Package-Builder is finishing at {}'.format(time.asctime()))


### PR DESCRIPTION
Cosmetic changes that show when the build/upload was done and how long it took.