### PR TITLE
 Allow for non-default channels such as conda-forge (try #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ package at any time using this command:
 $ conda uninstall taxcalc --yes
 ```
 
+If your package has dependencies that are not on the "PSLmodels" or "defaults" conda channels, then you should specify which channel(s) they are on with the "channel" argument:
+
+```
+pbrelease Your-Package yourpackage 1.0.0 --channel conda-forge
+```
+
 What are the package-building criteria?
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -68,22 +68,24 @@ channel for public distribution. The built/uploaded packages are for Python
 3.6 and Python 3.7.
 
 positional arguments:
-  REPOSITORY_NAME  Name of repository in the GitHub organization called
-                   PSLmodels. Example: Tax-Calculator
-  PACKAGE_NAME     Name of packages to build and upload. Example: taxcalc
-  MODEL_VERSION    Model release string that has X.Y.Z semantic-versioning
-                   pattern. Example: 1.0.1
+  REPOSITORY_NAME    Name of repository in the GitHub organization called
+                     PSLmodels. Example: Tax-Calculator
+  PACKAGE_NAME       Name of packages to build and upload. Example: taxcalc
+  MODEL_VERSION      Model release string that has X.Y.Z semantic-versioning
+                     pattern. Example: 1.0.1
 
 optional arguments:
-  -h, --help       show this help message and exit
-  --local          optional flag that causes package to be built from current
-                   source code and installed on local computer without
-                   packages being uploaded to Anaconda Cloud PSLmodels
-                   channel.
-  --dryrun         optional flag that writes execution plan to stdout and
-                   quits without executing plan
-  --version        optional flag that writes Package-Builder release version
-                   to stdout and quits
+  -h, --help         show this help message and exit
+  --local            optional flag that causes package to be built from
+                     current source code and installed on local computer
+                     without packages being uploaded to Anaconda Cloud
+                     PSLmodels channel.
+  --dryrun           optional flag that writes execution plan to stdout and
+                     quits without executing plan
+  --version          optional flag that writes Package-Builder release version
+                     to stdout and quits
+  --channel CHANNEL  Channel(s) to be used in addtion to 'defaults' and
+                     'pslmodels'.
 ```
 
 Once you can get this kind of `pbrelease` screen output, you're ready

--- a/pkgbld/cli.py
+++ b/pkgbld/cli.py
@@ -61,6 +61,11 @@ def main():
                               'release version to stdout and quits'),
                         default=False,
                         action="store_true")
+    parser.add_argument("--channel",
+                        help=("Channel(s) to be used in addtion to 'defaults' and "
+                              "'pslmodels'."),
+                        default=None,
+                        action="append")
     args = parser.parse_args()
     # show Package-Builder version and quit if --version option specified
     if args.version:
@@ -100,5 +105,6 @@ def main():
         return 1
     # call pkgbld release function with specified parameters
     pkgbld.release(repo_name, pkg_name, version,
-                   local=args.local, dryrun=args.dryrun)
+                   local=args.local, dryrun=args.dryrun,
+                   channels=args.channel)
     return 0

--- a/pkgbld/release.py
+++ b/pkgbld/release.py
@@ -31,7 +31,8 @@ WORKING_DIR = os.path.join(
 BUILDS_DIR = 'pkgbld_output'
 
 
-def release(repo_name, pkg_name, version, local=False, dryrun=False):
+def release(repo_name, pkg_name, version, local=False, dryrun=False,
+            channels=None):
     """
     If local==False, conduct build using cloned source code and
     upload to Anaconda Cloud conda packages for each operating-system
@@ -59,6 +60,9 @@ def release(repo_name, pkg_name, version, local=False, dryrun=False):
 
     dryrun: boolean
         whether or not just the package build/upload plan is shown
+
+    channels: list
+        list of packages to include in addition to pslmodels and defaults.
 
     Raises
     ------
@@ -118,6 +122,7 @@ def release(repo_name, pkg_name, version, local=False, dryrun=False):
     print(':   package_name = {}'.format(pkg_name))
     print(':   model_version = {}'.format(version))
     print(':   python_versions = {}'.format(python_versions))
+    print(':   additional channels= {}'.format(channels))
     if local:
         print(': Package-Builder will install package on local computer')
     else:
@@ -176,6 +181,10 @@ def release(repo_name, pkg_name, version, local=False, dryrun=False):
         replacement='__version__ = "{}"'.format(version)
     )
 
+    channel_str = f"--channel {ANACONDA_CHANNEL}"
+    for channel in channels or []:
+        channel_str += f" --channel {channel}"
+
     # build and upload model package for each Python version and OS platform
     local_platform = u.conda_platform_name()
     for pyver in python_versions:
@@ -183,9 +192,9 @@ def release(repo_name, pkg_name, version, local=False, dryrun=False):
         print((': Package-Builder is building package '
                'for Python {}').format(pyver))
         cmd = ('conda build --python {} --old-build-string '
-               '--channel {} --override-channels '
+               '{} --override-channels '
                '--no-anaconda-upload --output-folder {} '
-               'conda.recipe').format(pyver, ANACONDA_CHANNEL, BUILDS_DIR)
+               'conda.recipe').format(pyver, channel_str, BUILDS_DIR)
         u.os_call(cmd)
         # ... if local is True, skip convert and upload logic
         if local:


### PR DESCRIPTION
Resolves #166. This PR updates the `conda build` string with the additional channels that are required by the package. They should be specified like this:

```bash
pbrelease Your-Package yourpackage 1.0.0 --channel conda-forge
```
