### PR TITLE
Update to build with Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to install pbrelease?
 -------------------------
 
 At the operating-system command prompt on a computer that has the
-Anaconda distribution of Python 3.6 or 3.7 installed, execute this
+Anaconda distribution of Python 3.6, 3.7, or 3.8 installed, execute this
 command if you have never installed the package that contains the
 `pbrelease` tool:
 
@@ -65,7 +65,7 @@ Creates conda packages named PACKAGE_NAME for the PSL model in REPOSITORY_NAME
 that has a GitHub release named MODEL_VERSION. The packages are built locally
 in a temporary workspace and then uploaded to the Anaconda Cloud PSLmodels
 channel for public distribution. The built/uploaded packages are for Python
-3.6 and Python 3.7.
+3.6, 3.7, and 3.8.
 
 positional arguments:
   REPOSITORY_NAME  Name of repository in the GitHub organization called

--- a/pkgbld/cli.py
+++ b/pkgbld/cli.py
@@ -29,7 +29,7 @@ def main():
                      'in a temporary workspace and then uploaded to the '
                      'Anaconda Cloud PSLmodels channel for public '
                      'distribution.  The built/uploaded packages are '
-                     'for Python 3.6 and Python 3.7.')
+                     'for Python 3.6, 3.7, and 3.8.')
     )
     parser.add_argument('REPOSITORY_NAME', nargs='?',
                         help=('Name of repository in the GitHub organization '

--- a/pkgbld/release.py
+++ b/pkgbld/release.py
@@ -13,7 +13,7 @@ import shutil
 import pkgbld.utils as u
 
 
-ALL_PYTHON_VERSIONS = ['3.6', '3.7']
+ALL_PYTHON_VERSIONS = ['3.6', '3.7', '3.8']
 OS_PLATFORMS = ['osx-64', 'linux-64', 'win-32', 'win-64']
 
 GITHUB_URL = 'https://github.com/PSLmodels'

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ config = {
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules'],
     'tests_require': ['pytest']
 }

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ config = {
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules'],
-    'tests_require': ['pytest']
+    'tests_require': ['pytest'],
+    'entry_points': {
+        "console_scripts": ["pkgbld=pkgbld.cli:main"]
+    },
 }
 
 setup(**config)


### PR DESCRIPTION
This PR adds Python 3.8 as a build target for Package-Builder. I tested this the best I could by building a Tax-Calculator locally without publishing it.

Resolves #174