### PR TITLE
Use correct command for local installation pkgbld --> pbrelease

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ config = {
         'Topic :: Software Development :: Libraries :: Python Modules'],
     'tests_require': ['pytest'],
     'entry_points': {
-        "console_scripts": ["pkgbld=pkgbld.cli:main"]
+        "console_scripts": ["pbrelease=pkgbld.cli:main"]
     },
 }
 


### PR DESCRIPTION
It looks like I used the wrong command when adding the entry point to `setup.py` for easier use when working with the source code.

cc @MattHJensen 